### PR TITLE
Minor improvements to MiniMap

### DIFF
--- a/__tests__/miniMap.test.tsx
+++ b/__tests__/miniMap.test.tsx
@@ -103,6 +103,30 @@ describe("Map section", () => {
     });
   });
 
+  it("should make the other diocese names shadows when another diocese name is hovered over", () => {
+    render(<MiniMap />);
+
+    const southwarkDisplayName = screen.getByText("Southwark");
+    const westminsterDisplayName = screen.getByText("Westminster");
+
+    expect(southwarkDisplayName).toHaveClass("arial");
+    expect(westminsterDisplayName).toHaveClass("arial");
+
+    fireEvent.mouseOver(southwarkDisplayName);
+
+    expect(southwarkDisplayName).toHaveClass("embold");
+    expect(westminsterDisplayName).toHaveClass("shadow");
+
+    fireEvent.mouseOver(westminsterDisplayName);
+
+    expect(southwarkDisplayName).toHaveClass("shadow");
+    expect(westminsterDisplayName).toHaveClass("embold");
+
+    fireEvent.mouseOut(westminsterDisplayName);
+    expect(southwarkDisplayName).toHaveClass("arial");
+    expect(westminsterDisplayName).toHaveClass("arial");
+  });
+
   //TODO: Implement this test.
   //May require snapshot testing (hopefully not though)
   test.todo(
@@ -114,7 +138,7 @@ describe("Map section", () => {
   );
   test.todo(
     "should set a specific zoom for the map container and disable adjustments"
-  )
+  );
 
   function diocesesLayerWrapper() {
     return displayDiocesesLayer();

--- a/__tests__/miniMap.test.tsx
+++ b/__tests__/miniMap.test.tsx
@@ -29,8 +29,8 @@ describe("Map section", () => {
   });
   it("should have the correct background colour", () => {
     render(<MiniMap />);
-    const mapSection = screen.getByRole("miniMapContainer");
-    expect(mapSection).toHaveClass("miniMapContainer");
+    const mapSection = screen.getByRole("miniMapDiv");
+    expect(mapSection).toHaveClass("miniMapDiv");
   });
   it("should render a heading", () => {
     render(<MiniMap />);
@@ -107,6 +107,10 @@ describe("Map section", () => {
   //May require snapshot testing (hopefully not though)
   test.todo(
     "should highlight the correct diocese polygon only when I hover over the diocese name"
+  );
+  test.todo(
+    "should give the map container the same background colour as the section it's in"
+    //Maybe mock the mapcontainer?
   );
 
   function diocesesLayerWrapper() {

--- a/__tests__/miniMap.test.tsx
+++ b/__tests__/miniMap.test.tsx
@@ -138,6 +138,7 @@ describe("Map section", () => {
   );
   test.todo(
     "should set a specific zoom for the map container and disable adjustments"
+    //Including dragging, scrollwheelzoom, doubleclick zoom, and zooom buttons
   );
 
   function diocesesLayerWrapper() {

--- a/__tests__/miniMap.test.tsx
+++ b/__tests__/miniMap.test.tsx
@@ -112,6 +112,9 @@ describe("Map section", () => {
     "should give the map container the same background colour as the section it's in"
     //Maybe mock the mapcontainer?
   );
+  test.todo(
+    "should set a specific zoom for the map container and disable adjustments"
+  )
 
   function diocesesLayerWrapper() {
     return displayDiocesesLayer();

--- a/pages/components/MiniMap.tsx
+++ b/pages/components/MiniMap.tsx
@@ -36,7 +36,8 @@ export default function MiniMap() {
           <MapContainer
             center={center}
             zoom={5.5}
-            style={{ width: "70%", height: "400px" }}
+            style={{ width: "70%", height: "460px" }}
+            zoomControl={false}
             className={styles.miniMapContainer}
           >
             {displayDiocesesLayer(

--- a/pages/components/MiniMap.tsx
+++ b/pages/components/MiniMap.tsx
@@ -26,7 +26,7 @@ export default function MiniMap() {
       >
         Dioceses
       </h2>
-      <div role="miniMapContainer" className={styles.miniMapContainer}>
+      <div role="miniMapDiv" className={styles.miniMapDiv}>
         <div role={"miniMapSection"} className={styles.horizontalLayout}>
           {displayListOfDioceses(
             handleDioceseMouseover,
@@ -37,6 +37,7 @@ export default function MiniMap() {
             center={center}
             zoom={5.5}
             style={{ width: "70%", height: "400px" }}
+            className={styles.miniMapContainer}
           >
             {displayDiocesesLayer(
               hoveredDiocese,
@@ -59,7 +60,7 @@ export function displayListOfDioceses(
     a.properties.name.localeCompare(b.properties.name)
   );
   return (
-    <div className={styles.horizontalLayout}>
+    <div>
       <ul data-testid={"listedDioceses"} style={{ minWidth: 195 }}>
         {diocesesListedAlphabetically.map((diocese) => {
           const name = diocese.properties.name;

--- a/pages/components/MiniMap.tsx
+++ b/pages/components/MiniMap.tsx
@@ -38,6 +38,9 @@ export default function MiniMap() {
             zoom={5.5}
             style={{ width: "70%", height: "460px" }}
             zoomControl={false}
+            scrollWheelZoom={false}
+            doubleClickZoom={false}
+            dragging={false}
             className={styles.miniMapContainer}
           >
             {displayDiocesesLayer(

--- a/pages/components/MiniMap.tsx
+++ b/pages/components/MiniMap.tsx
@@ -65,13 +65,14 @@ export function displayListOfDioceses(
       <ul data-testid={"listedDioceses"} style={{ minWidth: 195 }}>
         {diocesesListedAlphabetically.map((diocese) => {
           const name = diocese.properties.name;
+          const textStyling = setTextClass(hoveredDiocese, name);
           return (
             <li
               key={diocese.properties.id}
               onMouseOver={() => handleDioceseMouseover(name)}
               onMouseOut={() => handleDioceseNameMouseout()}
               data-testid={`list-${name}`}
-              className={hoveredDiocese == name ? styles.embold : styles.arial}
+              className={textStyling}
             >
               {name}
             </li>
@@ -80,6 +81,21 @@ export function displayListOfDioceses(
       </ul>
     </div>
   );
+}
+
+function setTextClass(hoveredDiocese: string | null, dioceseName: string) {
+  let className: string;
+  switch (hoveredDiocese) {
+    case dioceseName:
+      className = styles.embold;
+      break;
+    case null:
+      className = styles.arial;
+      break;
+    default:
+      className = styles.shadow;
+  }
+  return className;
 }
 
 export function displayDiocesesLayer(

--- a/styles/MiniMap.module.scss
+++ b/styles/MiniMap.module.scss
@@ -15,7 +15,11 @@
   align-items: center;
 }
 
-.miniMapContainer {
+.miniMapDiv {
   background-color: var(--colour-grey-3);
   padding-right: 1em;
+}
+
+.miniMapContainer {
+  background-color: var(--colour-grey-3);
 }

--- a/styles/MiniMap.module.scss
+++ b/styles/MiniMap.module.scss
@@ -8,6 +8,12 @@
   font-family: "Arial";
 }
 
+.shadow {
+  font-family: "Arial";
+  font-weight: 100;
+  color: #c1d7eb;
+}
+
 .horizontalLayout {
   display: flex;
   flex-direction: row;


### PR DESCRIPTION
This PR provides further highlighting to the diocese name to make it easier to spot (by hiding the other dioceses): 

<img width="957" alt="image" src="https://github.com/user-attachments/assets/7c6e3866-793c-4580-810f-007f43356dd2" />

It also disables the user's ability to drag or zoom the miniMap. 
