### PR TITLE
Make Skeletons appear side-by-side

### DIFF
--- a/pages/components/SkeletonChart.tsx
+++ b/pages/components/SkeletonChart.tsx
@@ -9,7 +9,7 @@ export type SkeletonProps = {
 
 export default function SkeletonChart({rootTestId, heading, subheader}: SkeletonProps) {
   return (
-    <div data-testid={`${rootTestId}Skeleton`} className="w-full max-w-5/10">
+    <div data-testid={`${rootTestId}Skeleton`} className="w-full">
       <Link
         data-testid={`${rootTestId}Link`}
         href="/massAttendance"

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -31,19 +31,21 @@ export default function Home() {
           >
             Headlines
           </h2>
-          <div>
-            <SkeletonChart
-              rootTestId="massAttendance"
-              heading="Mass Attendance"
-              subheader="Sunday Mass attendance by year"
-            />
-          </div>
-          <div>
-            <SkeletonChart
-              rootTestId="conversions"
-              heading="Conversions"
-              subheader="Adult Receptions into the Church by year"
-            />
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <SkeletonChart
+                rootTestId="massAttendance"
+                heading="Mass Attendance"
+                subheader="Sunday Mass attendance by year"
+              />
+            </div>
+            <div>
+              <SkeletonChart
+                rootTestId="conversions"
+                heading="Conversions"
+                subheader="Adult Receptions into the Church by year"
+              />
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Skeleton graphs now appear side-by-side instead of being listed in one column: 
<img width="1456" alt="image" src="https://github.com/user-attachments/assets/7e6caeb5-e045-491a-a782-b4a513d3d77b" />
