### PR TITLE
Give navBar an exact margin

### DIFF
--- a/__tests__/components/navBar.test.tsx
+++ b/__tests__/components/navBar.test.tsx
@@ -26,4 +26,9 @@ describe("Navigation Bar", () => {
       "Catholic Data Dashboard"
     );
   });
+
+  it("gives the title a margin of 10", () => {
+    render(<NavBar />);
+    expect(screen.getByTestId("homePageLinkContainer")).toHaveClass("ml-10");
+  });
 });

--- a/pages/components/NavBar.tsx
+++ b/pages/components/NavBar.tsx
@@ -5,23 +5,17 @@ function NavBar() {
   return (
     <div>
       <title>UK Catholic Dashboard</title>
-      <header className="govuk-header border-none" data-testid="headerSection">
-        <div className="relative">
-          <div className="govuk-width-container relative flow-root">
-            <div className="govuk-header__content govuk-!-padding-top-2 inline w-auto">
-              <Link
-                data-testid="homePageLink"
-                href="/"
-                className="govuk-header__link govuk-header__service-name"
-              >
-                Catholic Data Dashboard
-              </Link>
-            </div>
-          </div>
+      <header className="govuk-header" data-testid="headerSection">
+        <div data-testid="homePageLinkContainer" className="ml-10">
+          <Link
+            data-testid="homePageLink"
+            href="/"
+            className="govuk-header__link govuk-header__service-name"
+          >
+            Catholic Data Dashboard
+          </Link>
         </div>
       </header>
-
-
     </div>
   );
 }


### PR DESCRIPTION
Stops the title floating in the middle of the page on larger screens