### PR TITLE
Make all p elements the correct class globally 

### DIFF
--- a/__tests__/__snapshots__/about.test.tsx.snap
+++ b/__tests__/__snapshots__/about.test.tsx.snap
@@ -40,19 +40,13 @@ exports[`About page has the expected text and formatting 1`] = `
         >
            What is the Catholic Data Dashboard?
         </h2>
-        <p
-          class="govuk-body"
-        >
+        <p>
           The Catholic Data Dashboard is a dashboard measuring the Catholic Church's impact on England & Wales.
         </p>
-        <p
-          class="govuk-body"
-        >
+        <p>
           In particular, it displays data and trends concerning the church's success in ministering the sacraments. 
         </p>
-        <p
-          class="govuk-body"
-        >
+        <p>
           It helps answer questions such as:
         </p>
         <ul
@@ -68,9 +62,7 @@ exports[`About page has the expected text and formatting 1`] = `
             Is the Catholic Church growing or shrinking in England & Wales? 
           </li>
         </ul>
-        <p
-          class="govuk-body"
-        >
+        <p>
           It seeks to answer questions like these in an easy-to-understand way.
         </p>
       </div>
@@ -80,14 +72,10 @@ exports[`About page has the expected text and formatting 1`] = `
         >
            Who is the dashboard for?
         </h2>
-        <p
-          class="govuk-body"
-        >
+        <p>
           As a Catholic interested in the health of the Catholic Church, I want to know if the church is growing or shrinking, so that I can plan accordingly. 
         </p>
-        <p
-          class="govuk-body"
-        >
+        <p>
           As a reader of newspaper reports about the Catholic Church, I want a comprehensive source of reliable statistics, so that I can put cherry-picked statistics into context.
         </p>
       </div>
@@ -97,9 +85,7 @@ exports[`About page has the expected text and formatting 1`] = `
         >
            Where does the data come from?
         </h2>
-        <p
-          class="govuk-body"
-        >
+        <p>
           All of the data used on this website is taken from 
           <a
             class="govuk-link"
@@ -111,9 +97,7 @@ exports[`About page has the expected text and formatting 1`] = `
           </a>
           , a project by the Catholic Record Society, and in particular by Timothea Kinnear and Dr Alana Harris. 
         </p>
-        <p
-          class="govuk-body"
-        >
+        <p>
           The Catholic Data Dashboard is not affiliated with the Catholicism in Numbers project in any form. 
         </p>
       </div>

--- a/__tests__/components/homePageHeader.test.tsx
+++ b/__tests__/components/homePageHeader.test.tsx
@@ -46,5 +46,6 @@ describe("Navigation Bar", () => {
 
     const betaNotice = screen.getByRole("betaNotice");
     expect(betaNotice).toBeInTheDocument();
+    expect(betaNotice).toHaveStyle({ "color": "#c1d7eb" });
   });
 });

--- a/components/HomePageHeader.tsx
+++ b/components/HomePageHeader.tsx
@@ -24,6 +24,7 @@ function HomePageHeader() {
           <p
             role={"betaNotice"}
             className={"pt-2.5 text-[var(--colour-offwhite)]"}
+            style={{color: "#c1d7eb"}}
           >
             {" "}
             <strong className={"govuk-tag govuk-phase-banner__content__tag "}>

--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -16,15 +16,15 @@ function About() {
             {" "}
             What is the Catholic Data Dashboard?
           </h2>
-          <p className="govuk-body">
+          <p>
             The Catholic Data Dashboard is a dashboard measuring the Catholic
             Church's impact on England & Wales.
           </p>
-          <p className="govuk-body">
+          <p>
             In particular, it displays data and trends concerning the church's
             success in ministering the sacraments.{" "}
           </p>
-          <p className="govuk-body">It helps answer questions such as:</p>
+          <p>It helps answer questions such as:</p>
           <ul className="govuk-list govuk-list--bullet">
             <li>How many people are attending Mass?</li>
             <li>How many people is the church converting each year?</li>
@@ -32,14 +32,14 @@ function About() {
               Is the Catholic Church growing or shrinking in England & Wales?{" "}
             </li>
           </ul>
-          <p className="govuk-body">
+          <p>
             It seeks to answer questions like these in an easy-to-understand
             way.
           </p>
         </div>
         <div>
           <h2 className="govuk-heading-l"> Who is the dashboard for?</h2>
-          <p className="govuk-body">
+          <p>
             As a Catholic interested in the health of the Catholic Church, I
             want to know if the church is growing or shrinking, so that I can
             plan accordingly.{" "}
@@ -50,7 +50,7 @@ function About() {
             which dioceses are better at converting people, so that I can learn
             from their approach.{" "}
           </p> */}
-          <p className="govuk-body">
+          <p>
             As a reader of newspaper reports about the Catholic Church, I want a
             comprehensive source of reliable statistics, so that I can put
             cherry-picked statistics into context.
@@ -58,7 +58,7 @@ function About() {
         </div>
         <div>
           <h2 className="govuk-heading-l"> Where does the data come from?</h2>
-          <p className="govuk-body">
+          <p>
             All of the data used on this website is taken from{" "}
             <a
               className="govuk-link"
@@ -69,7 +69,7 @@ function About() {
             , a project by the Catholic Record Society, and in particular by
             Timothea Kinnear and Dr Alana Harris.{" "}
           </p>
-          <p className="govuk-body">
+          <p>
             The Catholic Data Dashboard is not affiliated with the Catholicism
             in Numbers project in any form.{" "}
           </p>

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -5,30 +5,29 @@
   --background: #ffffff; /*White as snow*/
   --foreground: #171717;
 
-
   // Govuk brand colours
-  --colour-red: #{govuk-colour('red')};
-  --colour-yellow: #{govuk-colour('yellow')};
-  --colour-green: #{govuk-colour('green')};
-  --colour-blue: #{govuk-colour('blue')};
-  --colour-dark-blue: #{govuk-colour('dark-blue')};
-  --colour-light-blue: #{govuk-colour('light-blue')};
-  --colour-purple: #{govuk-colour('purple')};
+  --colour-red: #{govuk-colour("red")};
+  --colour-yellow: #{govuk-colour("yellow")};
+  --colour-green: #{govuk-colour("green")};
+  --colour-blue: #{govuk-colour("blue")};
+  --colour-dark-blue: #{govuk-colour("dark-blue")};
+  --colour-light-blue: #{govuk-colour("light-blue")};
+  --colour-purple: #{govuk-colour("purple")};
 
-  --colour-black: #{govuk-colour('black')};
-  --colour-dark-grey: #{govuk-colour('dark-grey')};
-  --colour-mid-grey: #{govuk-colour('mid-grey')};
-  --colour-light-grey: #{govuk-colour('light-grey')};
-  --colour-white: #{govuk-colour('white')};
+  --colour-black: #{govuk-colour("black")};
+  --colour-dark-grey: #{govuk-colour("dark-grey")};
+  --colour-mid-grey: #{govuk-colour("mid-grey")};
+  --colour-light-grey: #{govuk-colour("light-grey")};
+  --colour-white: #{govuk-colour("white")};
 
-  --colour-light-purple: #{govuk-colour('light-purple')};
-  --colour-bright-purple: #{govuk-colour('bright-purple')};
-  --colour-pink: #{govuk-colour('pink')};
-  --colour-light-pink: #{govuk-colour('light-pink')};
-  --colour-orange: #{govuk-colour('orange')};
-  --colour-brown: #{govuk-colour('brown')};
-  --colour-light-green: #{govuk-colour('light-green')};
-  --colour-turquoise: #{govuk-colour('turquoise')};
+  --colour-light-purple: #{govuk-colour("light-purple")};
+  --colour-bright-purple: #{govuk-colour("bright-purple")};
+  --colour-pink: #{govuk-colour("pink")};
+  --colour-light-pink: #{govuk-colour("light-pink")};
+  --colour-orange: #{govuk-colour("orange")};
+  --colour-brown: #{govuk-colour("brown")};
+  --colour-light-green: #{govuk-colour("light-green")};
+  --colour-turquoise: #{govuk-colour("turquoise")};
 
   // Govuk greys
   --colour-grey-1: #6b7376;
@@ -38,31 +37,32 @@
 
   --colour-offwhite: #c1d7eb;
 
-   --colour-chart-background: #f7f7f7;
+  --colour-chart-background: #f7f7f7;
   --colour-chart-background-hover: #edf5ff;
 }
 
-html, body{
+html,
+body {
   margin: 0;
-  height: 100%
+  height: 100%;
 }
 
-h1{
+h1 {
   color: var(--colour-white);
-  font-size:2.5em;
+  font-size: 2.5em;
   font-weight: 900;
 }
 
-h2{
+h2 {
   color: var(--colour-offwhite);
-  font-size:2.5em;
+  font-size: 2.5em;
   font-weight: 900;
+}
+
+p {
+  @extend .govuk-body;
 }
 
 .no-gds-typeface * {
   font-family: Arial, Helvetica, sans-serif !important;
 }
-
-
-
-


### PR DESCRIPTION
I have also given inline styling to the beta notice because tailwind was unable to override the global styling. 