### PR TITLE
Make graphs a large fixed size for mobile screens

### DIFF
--- a/__tests__/components/MakeAChart.test.tsx
+++ b/__tests__/components/MakeAChart.test.tsx
@@ -24,6 +24,7 @@ const dummyLineGraphProps = {
   xAxisValues: [
     2013, 2014, 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022, 2023,
   ],
+  widthHeightStyle: "blah de blah",
 };
 
 const dummyChartProps: ChartProps = {
@@ -63,6 +64,25 @@ describe("Make a chart", () => {
     const graph = await screen.findByRole("graph");
 
     expect(graph).toBeInTheDocument();
+  });
+
+  it("gives the graph the correct height and width", () => {
+    render(dummyChart);
+
+    const expectedStyling = {
+      width: "100%",
+      height: 270, //we set an exact height here to fix bug where graph gets longer and longer as you scroll on mobile
+      margin: 0,
+    };
+
+    const calls = mockedPlot.mock.calls;
+    const match = calls.find(
+      (props) =>
+        JSON.stringify(props[0].widthHeightStyle) ==
+        JSON.stringify(expectedStyling)
+    );
+
+    expect(match).toBeTruthy();
   });
 
   type GraphVariable = {

--- a/components/MakeAChart.tsx
+++ b/components/MakeAChart.tsx
@@ -50,6 +50,11 @@ export default function MakeAChart({
           yAxisValues={lineGraphData.yAxisValues}
           xAxisLabel={lineGraphData.xAxisLabel}
           xAxisValues={lineGraphData.xAxisValues}
+          widthHeightStyle={{
+            width: "100%",
+            height: 270,
+            margin: 0,
+          }}
         />
       </div>
     </div>

--- a/components/PlotALineGraph.tsx
+++ b/components/PlotALineGraph.tsx
@@ -6,6 +6,7 @@ export type LineGraphProps = {
   yAxisValues: Datum[];
   xAxisLabel: string;
   xAxisValues: Datum[];
+  widthHeightStyle: Object;
 };
 
 //TODO: Snapshot test this. Atm the only real "test" is looking at the rendered webpage myself
@@ -14,6 +15,7 @@ export default function PlotALineGraph({
   yAxisValues,
   xAxisLabel,
   xAxisValues,
+  widthHeightStyle,
 }: LineGraphProps) {
   return (
     <div data-testid="plottedLineGraph">
@@ -47,11 +49,7 @@ export default function PlotALineGraph({
             },
           },
         }}
-        style={{
-          width: "100%",
-          height: 270, //we set an exact height here to fix bug where graph gets longer and longer as you scroll on mobile
-          margin: 0,
-        }} //TODO: Move this style to a real class please. And test for minHeight. Or save for when we do snapshot testing
+        style={widthHeightStyle}
         useResizeHandler={true}
         config={{
           displayModeBar: false,

--- a/components/PlotALineGraph.tsx
+++ b/components/PlotALineGraph.tsx
@@ -9,49 +9,57 @@ export type LineGraphProps = {
 };
 
 //TODO: Snapshot test this. Atm the only real "test" is looking at the rendered webpage myself
-export default function PlotALineGraph({yAxisLabel, yAxisValues, xAxisLabel, xAxisValues}: LineGraphProps) {
+export default function PlotALineGraph({
+  yAxisLabel,
+  yAxisValues,
+  xAxisLabel,
+  xAxisValues,
+}: LineGraphProps) {
   return (
     <div data-testid="plottedLineGraph">
-    <Plot
-      data={[
-        {
-          x: xAxisValues,
-          y: yAxisValues,
-          type: "scatter",
-          mode: "lines+markers",
-          marker: { color: "#000066" },
-        },
-      ]}
-      layout={{
-        autosize: true,
-        margin: { t: 50, b: 60, l: 60, r: 30 },
-        xaxis: {
-          title: {
-            text: xAxisLabel,
-            font: {
-              size: 18,
+      <Plot
+        data={[
+          {
+            x: xAxisValues,
+            y: yAxisValues,
+            type: "scatter",
+            mode: "lines+markers",
+            marker: { color: "#000066" },
+          },
+        ]}
+        layout={{
+          autosize: true,
+          margin: { t: 50, b: 60, l: 60, r: 30 },
+          xaxis: {
+            title: {
+              text: xAxisLabel,
+              font: {
+                size: 18,
+              },
             },
           },
-        },
-        yaxis: {
-          title: {
-            text: yAxisLabel,
-            font: {
-              size: 18,
+          yaxis: {
+            title: {
+              text: yAxisLabel,
+              font: {
+                size: 18,
+              },
             },
           },
-        },
-      }}
-      style={{ width: "90%", height: "100%", minHeight:175, padding: "1.5em", margin: 0 }} //TODO: Move this style to a real class please. And test for minHeight. Or save for when we do snapshot testing
-      useResizeHandler={true}
-      config={{
-        displayModeBar: false //TODO: Consider switching this on
-      }}
-    />
+        }}
+        style={{
+          width: "100%",
+          height: 270, //we set an exact height here to fix bug where graph gets longer and longer as you scroll on mobile
+          margin: 0,
+        }} //TODO: Move this style to a real class please. And test for minHeight. Or save for when we do snapshot testing
+        useResizeHandler={true}
+        config={{
+          displayModeBar: false,
+        }}
+      />
     </div>
   );
 }
-
 
 //FYI: Use the PlotALineGraph function below if you want to make a skeleton outline graph for the homepage
 


### PR DESCRIPTION
This should stop a bug in which the graph gets longer and longer as you scroll on mobile view