### PR TITLE
Diocese Page Prototype

### DIFF
--- a/__mocks__/DataDisplayBox.tsx
+++ b/__mocks__/DataDisplayBox.tsx
@@ -1,0 +1,4 @@
+const DataDisplayBox = jest.fn(() => (
+  <div data-testid="mocked-data-display-box" />
+));
+export default DataDisplayBox;

--- a/__tests__/components/dataDisplayBox.test.tsx
+++ b/__tests__/components/dataDisplayBox.test.tsx
@@ -1,0 +1,93 @@
+jest.mock("@/components/MakeAChart", () => ({
+  __esModule: true,
+  default: jest.fn(() => <div data-testid="mocked-chart" />),
+}));
+jest.mock("@/components/Table", () => ({
+  __esModule: true,
+  default: jest.fn(() => <div data-testid="mocked-table" />),
+}));
+
+import DataDisplayBox, { DisplayBoxProps } from "@/components/DataDisplayBox";
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import { mocked } from "jest-mock";
+import MakeAChart from "@/components/MakeAChart";
+const mockedChart = mocked(MakeAChart, { shallow: false });
+import Table from "@/components/Table";
+const mockedTable = mocked(Table);
+
+const dummyProps: DisplayBoxProps = {
+  rootTestId: "blah",
+  dioceseDataKey: "westminsterMassAttendance",
+};
+
+describe("Data display box", () => {
+  it("has a box", () => {
+    render(<DataDisplayBox {...dummyProps} />);
+    const box = screen.getByTestId("blahDataDisplayBox");
+    expect(box).toBeInTheDocument();
+    expect(box).toHaveClass("bg-[var(--colour-grey-3)]");
+  });
+  it("gives the contents of the box the correct padding", () => {
+    render(<DataDisplayBox {...dummyProps} />);
+    const contents = screen.getByTestId("blahDataDisplayBoxContents");
+    expect(contents).toBeInTheDocument();
+    expect(contents).toHaveClass("m-6 pt-2 pb-0.25");
+  });
+  it("has a chart", () => {
+    render(<DataDisplayBox {...dummyProps} />);
+    const chart = screen.getByTestId("blahChartSection");
+    expect(chart).toBeInTheDocument();
+  });
+
+  it("gives the chart the correct props", async () => {
+    render(<DataDisplayBox {...dummyProps} />);
+
+    const expectedChartData = {
+      heading: "Typical Sunday Mass Attendance",
+      contextParagraph:
+        "Typical number of people attending Sunday Mass in the Diocese of Westminster",
+      lineGraphData: {
+        xAxisLabel: "Year",
+        yAxisLabel: "Number attending Mass",
+        xAxisValues: [2022, 2021, 2018, 2008, 1999],
+        yAxisValues: [90202, 74308, 127340, 151668, 154042],
+      },
+    };
+
+    const calls = mockedChart.mock.calls;
+    const match = calls.find(
+      ([props]) => JSON.stringify(props) === JSON.stringify(expectedChartData)
+    );
+
+    expect(match).toBeTruthy();
+  });
+
+  it("has a table", () => {
+    render(<DataDisplayBox {...dummyProps} />);
+    const table = screen.getByTestId("blahTableSection");
+    expect(table).toBeInTheDocument();
+  });
+
+  it("gives the table the correct props", () => {
+    render(<DataDisplayBox {...dummyProps} />);
+
+    const expectedTableData = {
+      columns: { keyColumn: "Year", valueColumn: "Number attending Mass" },
+      rows: [
+        { year: 2022, value: 90202 },
+        { year: 2021, value: 74308 },
+        { year: 2018, value: 127340 },
+        { year: 2008, value: 151668 },
+        { year: 1999, value: 154042 },
+      ],
+    };
+
+    const calls = mockedTable.mock.calls;
+    const match = calls.find(
+      ([props]) => JSON.stringify(props) === JSON.stringify(expectedTableData)
+    );
+
+    expect(match).toBeTruthy();
+  });
+});

--- a/__tests__/components/topicSection.test.tsx
+++ b/__tests__/components/topicSection.test.tsx
@@ -1,0 +1,60 @@
+jest.mock("@/components/DataDisplayBox", () => ({
+  __esModule: true,
+  default: jest.fn(() => <div data-testid="mocked-data-display-box" />),
+}));
+
+import DataDisplayBox, { DisplayBoxProps } from "@/components/DataDisplayBox";
+const mockedDataDisplayBox = mocked(DataDisplayBox);
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import { mocked } from "jest-mock";
+import TopicSection, { TopicSectionProps } from "@/components/TopicSection";
+
+const dummyProps: TopicSectionProps = {
+  topicName: "An important topic",
+  rootTestId: "blah",
+  dioceseDataKey: "westminsterMassAttendance",
+};
+
+describe("Topic Section", () => {
+  it("has the correct heading", () => {
+    render(<TopicSection {...dummyProps} />);
+    const topicSectionHeading = screen.getByTestId("blahTopicSectionHeading");
+    expect(topicSectionHeading).toBeInTheDocument();
+    expect(topicSectionHeading).toHaveClass("govuk-heading-l");
+    expect(topicSectionHeading).toHaveTextContent("An important topic");
+  });
+
+  it("has an accuracy subheading", () => {
+    render(<TopicSection {...dummyProps} />);
+    const accuracySubheading = screen.getByTestId("blahAccuracySubheading");
+    expect(accuracySubheading).toBeInTheDocument();
+    expect(accuracySubheading).toHaveTextContent("Note on accuracy of data");
+  });
+
+  it("has the correct accuracy statement", () => {
+    render(<TopicSection {...dummyProps} />);
+    const accuracyStatement = screen.getByTestId("blahAccuracy");
+    expect(accuracyStatement).toBeInTheDocument();
+    expect(accuracyStatement).toHaveTextContent(
+      "The accuracy with which attendance is counted may vary. A person may accidentally be counted twice and figures may overstate or understate where an estimate is required, such as at very large services or if mechanical means of counting fail. Additionally, approaches to counting may vary across churches in a diocese or nation."
+    );
+  });
+
+  it("gives the data-display box the correct props", async () => {
+    render(<TopicSection {...dummyProps} />);
+
+    const expectedDisplayBoxProps = {
+      rootTestId: "blah",
+      dioceseDataKey: "westminsterMassAttendance",
+    };
+
+    const calls = mockedDataDisplayBox.mock.calls;
+    const match = calls.find(
+      ([props]) =>
+        JSON.stringify(props) === JSON.stringify(expectedDisplayBoxProps)
+    );
+
+    expect(match).toBeTruthy();
+  });
+});

--- a/components/DataDisplayBox.tsx
+++ b/components/DataDisplayBox.tsx
@@ -1,0 +1,51 @@
+import { getDioceseData } from "@/data/dioceseStats";
+import { DioceseDbKey } from "@/data/enums";
+import { LineGraphProps } from "./PlotALineGraph";
+import MakeAChart from "./MakeAChart";
+import Table from "./Table";
+
+export type DisplayBoxProps = {
+  rootTestId: string;
+  dioceseDataKey: DioceseDbKey;
+};
+
+function DataDisplayBox({ rootTestId, dioceseDataKey }: DisplayBoxProps) {
+  const dioceseDataTable = getDioceseData(dioceseDataKey);
+
+  const lineGraphDataforConverts: LineGraphProps = {
+    xAxisLabel: dioceseDataTable.data.columnHeadings.keyColumn,
+    yAxisLabel: dioceseDataTable.data.columnHeadings.valueColumn,
+    xAxisValues: dioceseDataTable.data.rowData.map((row) => row.year),
+    yAxisValues: dioceseDataTable.data.rowData.map((row) => row.value),
+  };
+
+  return (
+    <div
+      data-testid={`${rootTestId}DataDisplayBox`}
+      className="bg-[var(--colour-grey-3)]"
+    >
+      <div
+        data-testid={`${rootTestId}DataDisplayBoxContents`}
+        className="m-6 pt-2 pb-0.25"
+      >
+        <div data-testid={`${rootTestId}ChartSection`}>
+          <MakeAChart
+            heading={dioceseDataTable.context.heading}
+            contextParagraph={dioceseDataTable.context.contextParagraph}
+            lineGraphData={lineGraphDataforConverts}
+          />
+        </div>
+        <div>
+          <div data-testid={`${rootTestId}TableSection`}>
+            <Table
+              columns={dioceseDataTable.data.columnHeadings}
+              rows={dioceseDataTable.data.rowData}
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default DataDisplayBox;

--- a/components/TopicSection.tsx
+++ b/components/TopicSection.tsx
@@ -1,0 +1,36 @@
+import { getDioceseData } from "@/data/dioceseStats";
+import { DioceseDbKey } from "@/data/enums";
+import DataDisplayBox from "./DataDisplayBox";
+
+export type TopicSectionProps = {
+  topicName: string;
+  dioceseDataKey: DioceseDbKey;
+  rootTestId: string;
+};
+
+function TopicSection({
+  topicName,
+  dioceseDataKey,
+  rootTestId,
+}: TopicSectionProps) {
+  const accuracyStatement = getDioceseData(dioceseDataKey).accuracy;
+  return (
+    <div>
+      <h2
+        data-testId={`${rootTestId}TopicSectionHeading`}
+        className="govuk-heading-l"
+      >
+        {topicName}
+      </h2>
+      <strong data-testId={`${rootTestId}AccuracySubheading`}>
+        Note on accuracy of data
+      </strong>
+      <p data-testId={`${rootTestId}Accuracy`}>{accuracyStatement}</p>
+      <DataDisplayBox
+        {...{ rootTestId: rootTestId, dioceseDataKey: dioceseDataKey }}
+      />
+    </div>
+  );
+}
+
+export default TopicSection;

--- a/data/dioceseStats.ts
+++ b/data/dioceseStats.ts
@@ -1,0 +1,63 @@
+import { DioceseDbKey } from "./enums";
+import { TableData } from "./nationalStats"; //TODO: Organise typing
+
+const MA_ACCURACY_STATEMENT =
+  "The accuracy with which attendance is counted may vary. A person may accidentally be counted twice and figures may overstate or understate where an estimate is required, such as at very large services or if mechanical means of counting fail. Additionally, approaches to counting may vary across churches in a diocese or nation.";
+  const CONVERSIONS_ACCURACY_STATEMENT = "The data below records receptions into the Catholic Church. It does not include figures for adult baptisms.";
+
+const westminsterConversionsTable: TableData = {
+  columnHeadings: {
+    keyColumn: "Year",
+    valueColumn: "Converts to Catholicism",
+  },
+  rowData: [
+    { year: 2022, value: 227 },
+    { year: 2021, value: 193 },
+    { year: 2019, value: 298 },
+    { year: 2010, value: 628 },
+    { year: 2000, value: 541 },
+  ],
+};
+
+const westminsterConversionsData = {
+  context: {
+    heading: "Conversions to Catholicism in the Diocese of Westminster",
+    contextParagraph:
+      "Receptions into the Catholic Church in the Diocese of Westminster",
+  },
+  data: westminsterConversionsTable,
+  accuracy: CONVERSIONS_ACCURACY_STATEMENT
+};
+
+const westminsterMassAttendanceTable: TableData = {
+  columnHeadings: {
+    keyColumn: "Year",
+    valueColumn: "Number attending Mass",
+  },
+  rowData: [
+    { year: 2022, value: 90202 },
+    { year: 2021, value: 74308 },
+    { year: 2018, value: 127340 },
+    { year: 2008, value: 151668 },
+    { year: 1999, value: 154042 },
+  ],
+};
+
+const westminsterMassAttendanceData = {
+  context: {
+    heading: "Typical Sunday Mass Attendance",
+    contextParagraph:
+      "Typical number of people attending Sunday Mass in the Diocese of Westminster",
+  },
+  data: westminsterMassAttendanceTable,
+  accuracy: MA_ACCURACY_STATEMENT
+};
+
+export const DioceseSimpleDb = {
+  westminsterMassAttendance: westminsterMassAttendanceData,
+  westminsterConversions: westminsterConversionsData,
+};
+
+export function getDioceseData(keyName: DioceseDbKey) {
+  return DioceseSimpleDb[keyName];
+}

--- a/data/enums.ts
+++ b/data/enums.ts
@@ -1,3 +1,4 @@
+import { DioceseSimpleDb } from "./dioceseStats";
 import { SimpleDb } from "./nationalStats";
 export const validDioceseNames = [
   "Arundel & Brighton",
@@ -50,3 +51,4 @@ export const cleanedDioceseNames = [
 export type CleanedDioceseName = (typeof cleanedDioceseNames)[number];
 
 export type DbKey = keyof typeof SimpleDb;
+export type DioceseDbKey = keyof typeof DioceseSimpleDb

--- a/data/nationalStats.ts
+++ b/data/nationalStats.ts
@@ -1,7 +1,7 @@
 import { TableColumns, TableRow } from "@/components/Table";
 import { DbKey } from "./enums";
 
-type TableData = {
+export type TableData = {
   columnHeadings: TableColumns;
   rowData: TableRow[];
 };

--- a/pages/westminster.tsx
+++ b/pages/westminster.tsx
@@ -1,9 +1,7 @@
 import React from "react";
 import DashboardFooter from "../components/DashboardFooter";
 import NavBar from "../components/NavBar";
-import { DioceseDbKey } from "@/data/enums";
-import { getDioceseData } from "@/data/dioceseStats";
-import DataDisplayBox from "@/components/DataDisplayBox";
+import TopicSection from "@/components/TopicSection";
 
 export type DiocesePageProps = {
   rootTestId: string;
@@ -33,17 +31,16 @@ function WestminsterPage({ rootTestId }: DiocesePageProps) {
             , a project by the Catholic Record Society.
           </p>
         </div>
-        {topicSection(
-          "Conversions",
-          "westminsterConversions",
-          "westminsterConversions"
-        )}
-
-        {topicSection(
-          "Mass Attendance",
-          "westminsterMassAttendance",
-          "westminsterMassAttendance"
-        )}
+        <TopicSection
+          rootTestId="westminsterConversions"
+          dioceseDataKey="westminsterConversions"
+          topicName="Conversions"
+        />
+        <TopicSection
+          rootTestId="westminsterMassAttendance"
+          dioceseDataKey="westminsterMassAttendance"
+          topicName="Mass Attendance"
+        />
       </div>
       <DashboardFooter />
     </div>
@@ -51,21 +48,3 @@ function WestminsterPage({ rootTestId }: DiocesePageProps) {
 }
 
 export default WestminsterPage;
-
-function topicSection(
-  topicName: string,
-  dioceseTopicKey: DioceseDbKey,
-  rootTestId: string
-) {
-  const accuracyStatement = getDioceseData(dioceseTopicKey).accuracy;
-  return (
-    <div>
-      <h2 className="govuk-heading-l">{topicName}</h2>
-      <strong>Note on accuracy of data</strong>
-      <p>{accuracyStatement}</p>
-      <DataDisplayBox
-        {...{ rootTestId: rootTestId, dioceseDataKey: dioceseTopicKey }}
-      />
-    </div>
-  );
-}

--- a/pages/westminster.tsx
+++ b/pages/westminster.tsx
@@ -1,0 +1,71 @@
+import React from "react";
+import DashboardFooter from "../components/DashboardFooter";
+import NavBar from "../components/NavBar";
+import { DioceseDbKey } from "@/data/enums";
+import { getDioceseData } from "@/data/dioceseStats";
+import DataDisplayBox from "@/components/DataDisplayBox";
+
+export type DiocesePageProps = {
+  rootTestId: string;
+};
+
+function WestminsterPage({ rootTestId }: DiocesePageProps) {
+  return (
+    <div>
+      <NavBar />
+      <div className="m-10">
+        <h1 data-testid={`${rootTestId}PageTitle`} className="govuk-heading-xl">
+          Diocese of Westminster
+        </h1>
+        <div data-testid="citation">
+          <b>Citation</b>
+          <p data-testid="citationText">
+            The data on this page comes from{" "}
+            <i>
+              <a
+                data-testid="citationLink"
+                className="govuk-link"
+                href="https://www.crs.org.uk/catholicism-in-numbers"
+              >
+                Catholicism in Numbers
+              </a>
+            </i>
+            , a project by the Catholic Record Society.
+          </p>
+        </div>
+        {topicSection(
+          "Conversions",
+          "westminsterConversions",
+          "westminsterConversions"
+        )}
+
+        {topicSection(
+          "Mass Attendance",
+          "westminsterMassAttendance",
+          "westminsterMassAttendance"
+        )}
+      </div>
+      <DashboardFooter />
+    </div>
+  );
+}
+
+export default WestminsterPage;
+
+function topicSection(
+  topicName: string,
+  dioceseTopicKey: DioceseDbKey,
+  rootTestId: string
+) {
+  const accuracyStatement = getDioceseData(dioceseTopicKey).accuracy;
+  return (
+    <div>
+      <h2 className="govuk-heading-l">{topicName}</h2>
+      <strong>Note on accuracy of data</strong>
+      <p>{accuracyStatement}</p>
+      <DataDisplayBox
+        {...{ rootTestId: rootTestId, dioceseDataKey: dioceseTopicKey }}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
The Data Display Box consists of a title, subtitle, graph and table like so: 
<img width="1390" alt="image" src="https://github.com/user-attachments/assets/94d7ca92-9037-4e00-8aee-88e08eebadbe" />

The diocese page lists all data associated with the diocese of Westminster (currently, mass attendance and receptions into the church)