### PR TITLE
Restructure diocese database

### DIFF
--- a/__tests__/components/dataDisplayBox.test.tsx
+++ b/__tests__/components/dataDisplayBox.test.tsx
@@ -14,11 +14,12 @@ import { mocked } from "jest-mock";
 import MakeAChart from "@/components/MakeAChart";
 const mockedChart = mocked(MakeAChart, { shallow: false });
 import Table from "@/components/Table";
+import { westminsterMassAttendanceData } from "@/data/dioceseStats";
 const mockedTable = mocked(Table);
 
 const dummyProps: DisplayBoxProps = {
   rootTestId: "blah",
-  dioceseDataKey: "westminsterMassAttendance",
+  topic: westminsterMassAttendanceData
 };
 
 describe("Data display box", () => {

--- a/__tests__/components/topicSection.test.tsx
+++ b/__tests__/components/topicSection.test.tsx
@@ -3,17 +3,18 @@ jest.mock("@/components/DataDisplayBox", () => ({
   default: jest.fn(() => <div data-testid="mocked-data-display-box" />),
 }));
 
-import DataDisplayBox, { DisplayBoxProps } from "@/components/DataDisplayBox";
+import DataDisplayBox from "@/components/DataDisplayBox";
 const mockedDataDisplayBox = mocked(DataDisplayBox);
 import "@testing-library/jest-dom";
 import { render, screen } from "@testing-library/react";
 import { mocked } from "jest-mock";
 import TopicSection, { TopicSectionProps } from "@/components/TopicSection";
+import { westminsterMassAttendanceData } from "@/data/dioceseStats";
 
 const dummyProps: TopicSectionProps = {
   topicName: "An important topic",
+  topicData: westminsterMassAttendanceData,
   rootTestId: "blah",
-  dioceseDataKey: "westminsterMassAttendance",
 };
 
 describe("Topic Section", () => {
@@ -46,7 +47,7 @@ describe("Topic Section", () => {
 
     const expectedDisplayBoxProps = {
       rootTestId: "blah",
-      dioceseDataKey: "westminsterMassAttendance",
+      topic: westminsterMassAttendanceData,
     };
 
     const calls = mockedDataDisplayBox.mock.calls;

--- a/components/DataDisplayBox.tsx
+++ b/components/DataDisplayBox.tsx
@@ -1,22 +1,19 @@
-import { getDioceseData } from "@/data/dioceseStats";
-import { DioceseDbKey } from "@/data/enums";
+import { TopicData } from "@/data/dioceseStats";
 import { LineGraphProps } from "./PlotALineGraph";
 import MakeAChart from "./MakeAChart";
 import Table from "./Table";
 
 export type DisplayBoxProps = {
   rootTestId: string;
-  dioceseDataKey: DioceseDbKey;
+  topic: TopicData;
 };
 
-function DataDisplayBox({ rootTestId, dioceseDataKey }: DisplayBoxProps) {
-  const dioceseDataTable = getDioceseData(dioceseDataKey);
-
+function DataDisplayBox({ rootTestId, topic }: DisplayBoxProps) {
   const lineGraphDataforConverts: LineGraphProps = {
-    xAxisLabel: dioceseDataTable.data.columnHeadings.keyColumn,
-    yAxisLabel: dioceseDataTable.data.columnHeadings.valueColumn,
-    xAxisValues: dioceseDataTable.data.rowData.map((row) => row.year),
-    yAxisValues: dioceseDataTable.data.rowData.map((row) => row.value),
+    xAxisLabel: topic.tableData.columnHeadings.keyColumn,
+    yAxisLabel: topic.tableData.columnHeadings.valueColumn,
+    xAxisValues: topic.tableData.rowData.map((row) => row.year),
+    yAxisValues: topic.tableData.rowData.map((row) => row.value),
   };
 
   return (
@@ -30,16 +27,16 @@ function DataDisplayBox({ rootTestId, dioceseDataKey }: DisplayBoxProps) {
       >
         <div data-testid={`${rootTestId}ChartSection`}>
           <MakeAChart
-            heading={dioceseDataTable.context.heading}
-            contextParagraph={dioceseDataTable.context.contextParagraph}
+            heading={topic.context.heading}
+            contextParagraph={topic.context.contextParagraph}
             lineGraphData={lineGraphDataforConverts}
           />
         </div>
         <div>
           <div data-testid={`${rootTestId}TableSection`}>
             <Table
-              columns={dioceseDataTable.data.columnHeadings}
-              rows={dioceseDataTable.data.rowData}
+              columns={topic.tableData.columnHeadings}
+              rows={topic.tableData.rowData}
             />
           </div>
         </div>

--- a/components/TopicSection.tsx
+++ b/components/TopicSection.tsx
@@ -1,33 +1,30 @@
-import { getDioceseData } from "@/data/dioceseStats";
-import { DioceseDbKey } from "@/data/enums";
+import { TopicData } from "@/data/dioceseStats";
 import DataDisplayBox from "./DataDisplayBox";
 
 export type TopicSectionProps = {
   topicName: string;
-  dioceseDataKey: DioceseDbKey;
+  topicData: TopicData;
   rootTestId: string;
 };
 
-function TopicSection({
-  topicName,
-  dioceseDataKey,
-  rootTestId,
-}: TopicSectionProps) {
-  const accuracyStatement = getDioceseData(dioceseDataKey).accuracy;
+function TopicSection({ topicName, topicData, rootTestId }: TopicSectionProps) {
   return (
     <div>
       <h2
-        data-testId={`${rootTestId}TopicSectionHeading`}
+        data-testid={`${rootTestId}TopicSectionHeading`}
         className="govuk-heading-l"
       >
         {topicName}
       </h2>
-      <strong data-testId={`${rootTestId}AccuracySubheading`}>
+      <strong data-testid={`${rootTestId}AccuracySubheading`}>
         Note on accuracy of data
       </strong>
-      <p data-testId={`${rootTestId}Accuracy`}>{accuracyStatement}</p>
+      <p data-testid={`${rootTestId}Accuracy`}>{topicData.accuracy}</p>
       <DataDisplayBox
-        {...{ rootTestId: rootTestId, dioceseDataKey: dioceseDataKey }}
+        {...{
+          rootTestId: rootTestId,
+          topic: topicData,
+        }}
       />
     </div>
   );

--- a/data/dioceseStats.ts
+++ b/data/dioceseStats.ts
@@ -3,7 +3,8 @@ import { TableData } from "./nationalStats"; //TODO: Organise typing
 
 const MA_ACCURACY_STATEMENT =
   "The accuracy with which attendance is counted may vary. A person may accidentally be counted twice and figures may overstate or understate where an estimate is required, such as at very large services or if mechanical means of counting fail. Additionally, approaches to counting may vary across churches in a diocese or nation.";
-  const CONVERSIONS_ACCURACY_STATEMENT = "The data below records receptions into the Catholic Church. It does not include figures for adult baptisms.";
+const CONVERSIONS_ACCURACY_STATEMENT =
+  "The data below records receptions into the Catholic Church. It does not include figures for adult baptisms.";
 
 const westminsterConversionsTable: TableData = {
   columnHeadings: {
@@ -25,8 +26,8 @@ const westminsterConversionsData = {
     contextParagraph:
       "Receptions into the Catholic Church in the Diocese of Westminster",
   },
-  data: westminsterConversionsTable,
-  accuracy: CONVERSIONS_ACCURACY_STATEMENT
+  tableData: westminsterConversionsTable,
+  accuracy: CONVERSIONS_ACCURACY_STATEMENT,
 };
 
 const westminsterMassAttendanceTable: TableData = {
@@ -43,19 +44,39 @@ const westminsterMassAttendanceTable: TableData = {
   ],
 };
 
-const westminsterMassAttendanceData = {
+export const westminsterMassAttendanceData = {
   context: {
     heading: "Typical Sunday Mass Attendance",
     contextParagraph:
       "Typical number of people attending Sunday Mass in the Diocese of Westminster",
   },
-  data: westminsterMassAttendanceTable,
-  accuracy: MA_ACCURACY_STATEMENT
+  tableData: westminsterMassAttendanceTable,
+  accuracy: MA_ACCURACY_STATEMENT,
 };
 
-export const DioceseSimpleDb = {
-  westminsterMassAttendance: westminsterMassAttendanceData,
-  westminsterConversions: westminsterConversionsData,
+export type TopicData = {
+  context: {
+    heading: string;
+    contextParagraph: string;
+  };
+  tableData: TableData;
+  accuracy: string;
+};
+
+type DioceseData = {
+  massAttendance: TopicData;
+  conversions: TopicData;
+};
+
+type DioceseDb = {
+  westminster: DioceseData;
+};
+
+export const DioceseSimpleDb: DioceseDb = {
+  westminster: {
+    massAttendance: westminsterMassAttendanceData,
+    conversions: westminsterConversionsData,
+  },
 };
 
 export function getDioceseData(keyName: DioceseDbKey) {

--- a/data/enums.ts
+++ b/data/enums.ts
@@ -51,4 +51,4 @@ export const cleanedDioceseNames = [
 export type CleanedDioceseName = (typeof cleanedDioceseNames)[number];
 
 export type DbKey = keyof typeof SimpleDb;
-export type DioceseDbKey = keyof typeof DioceseSimpleDb
+export type DioceseDbKey = keyof typeof DioceseSimpleDb;

--- a/pages/westminster.tsx
+++ b/pages/westminster.tsx
@@ -2,12 +2,14 @@ import React from "react";
 import DashboardFooter from "../components/DashboardFooter";
 import NavBar from "../components/NavBar";
 import TopicSection from "@/components/TopicSection";
+import { getDioceseData } from "@/data/dioceseStats";
 
 export type DiocesePageProps = {
   rootTestId: string;
 };
 
 function WestminsterPage({ rootTestId }: DiocesePageProps) {
+  const dioceseData = getDioceseData("westminster");
   return (
     <div>
       <NavBar />
@@ -33,13 +35,13 @@ function WestminsterPage({ rootTestId }: DiocesePageProps) {
         </div>
         <TopicSection
           rootTestId="westminsterConversions"
-          dioceseDataKey="westminsterConversions"
           topicName="Conversions"
+          topicData={dioceseData.conversions}
         />
-        <TopicSection
+         <TopicSection
           rootTestId="westminsterMassAttendance"
-          dioceseDataKey="westminsterMassAttendance"
           topicName="Mass Attendance"
+          topicData={dioceseData.massAttendance}
         />
       </div>
       <DashboardFooter />


### PR DESCRIPTION
Key difference is this: 
```typeScript
export const DioceseSimpleDb = {
  westminsterMassAttendance: westminsterMassAttendanceData,
  westminsterConversions: westminsterConversionsData,
};
```
has become this: 
```typeScript
export const DioceseSimpleDb: DioceseDb = {
  westminster: {
    massAttendance: westminsterMassAttendanceData,
    conversions: westminsterConversionsData,
  },
};
```

This means we can fetch all the data for a diocese in one go at the diocesePage. The relevant data is then passed into each topic section and so on. 